### PR TITLE
Use JSON.stringify instead of template strings for formatting

### DIFF
--- a/src/autorun.ts
+++ b/src/autorun.ts
@@ -46,6 +46,7 @@ interface WTRQUnitTestEndResult {
   errors: WTRQUnitTestEndResultAssertion[]
 }
 // for some reason the suite assertions do not include expected/action output
+// https://github.com/qunitjs/qunit/issues/1737#issuecomment-1932895219
 interface WTRQUnitSuiteTestAssertion {
   passed: boolean
   message: string
@@ -209,8 +210,8 @@ function collectErrors (qunitTestEndResult: WTRQUnitTestEndResult): WTRQunitTest
       name,
       message: error.message,
       stack: error.stack,
-      expected: `${error.expected}`,
-      actual: `${error.actual}`,
+      expected: JSON.stringify(error.expected, null, 2),
+      actual: JSON.stringify(error.actual, null, 2),
       __wtr_qunit_identifier__: error.__wtr_qunit_identifier__
     }
     errors.push(testResultError)


### PR DESCRIPTION
Hi @brandonaaron. Thank you for taking action on this issue. I just tried your changes locally and it looks good. Unfortunately it is necessary right now to re-map the errors, but no matter the implementation, now it's possible to do TDD with WTR and QUnit, which is awesome.

I just changed the actual/expected casting using JSON.stringify as we often compare structures and this makes the diffs way more readable.

It would be very nice to have a release with the improvements soon, so i can finally start migrating away from karma.

Thanks